### PR TITLE
Refactored control scheme, added toggleable intake

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -185,16 +185,17 @@ public class RobotContainer {
         .ignoringDisable(true));
 
     // Spin up when A is held (use this if you don't want to lock position)
-    controller.rightBumper()
+    controller.a()
         .whileTrue(shooter.runSpinner());
 
     // Climb/cancel climb when B button is pressed
     // TODO: implement climbing
+    // controller.b()
+    //    .onTrue(new ConditionalCommand(climber.retract(), climber.extend(), () -> climber.getClimberExtended()));
 
     // Switch to X pattern when X button is pressed
     controller.x()
-        .whileTrue(indexer.reverseIndexer()
-        .andThen(indexer.stopIndexer()));
+        .whileTrue(indexer.reverseIndexer());
 
     // Outtake when Y button is held
     controller.y()
@@ -218,17 +219,14 @@ public class RobotContainer {
 
     // Toggle intake when left bumper is pressed
     controller.leftBumper()
-        .onTrue(new ConditionalCommand(intake.setIntakeMaxLength(), intake.setIntakeMinLength(), () -> intake.getIntakeDeployedSwitch()));
+        .onTrue(new ConditionalCommand(intake.setIntakeMinLength(), intake.setIntakeMaxLength(), () -> intake.getIntakeDeployedSwitch()));
 
     // Run intake when left trigger is held
     controller.leftTrigger()
         .whileTrue((intake.runIntake(IntakeConstants.intakeSpeed)
         .alongWith(indexer.runIndexer()))
-        .andThen(intake.stopIntake()
-        .alongWith(indexer.stopIndexer())));
-
-    controller.povRight()
-        .onTrue(drive.getTestAllPointsCommand());
+        .alongWith(shooter.reverseKicker()));
+        
 
     controller.povUp()
         .onTrue(Commands.runOnce(() -> 

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -34,7 +34,7 @@ public class DriveCommands {
   private static final double DEADBAND = 0.1;
   private static final double ANGLE_KP = 5.0;
   private static final double ANGLE_KD = 0.4;
-  private static final double ANGLE_MAX_VELOCITY = 8.0;
+  private static final double ANGLE_MAX_VELOCITY = 12.0;
   private static final double ANGLE_MAX_ACCELERATION = 20.0;
   private static final double FF_START_DELAY = 2.0; // Secs
   private static final double FF_RAMP_RATE = 0.1; // Volts/Sec
@@ -92,7 +92,7 @@ public class DriveCommands {
                   isFlipped
                       ? drive.getRotation().plus(new Rotation2d(Math.PI))
                       : drive.getRotation()));
-          if (linearVelocity.getX() == 0 && linearVelocity.getY() == 0.0) {
+          if (Math.abs(linearVelocity.getX()) <= 0.1 && Math.abs(linearVelocity.getY()) <= 0.1 && Math.abs(omega) <= 0.1) {
             drive.stopWithX();
           }
         },

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -30,15 +30,15 @@ public class Indexer extends SubsystemBase{
     }
 
     public Command runIndexer(){
-        return Commands.runEnd(()-> this.io.runIndexerAtSpeed(indexMotorSpeedSetpoint), ()-> this.io.stopIntake());
+        return Commands.runEnd(()-> this.io.runIndexerAtSpeed(indexMotorSpeedSetpoint), ()-> this.io.stopIndexer());
     }
 
     public Command reverseIndexer(){
-        return Commands.runEnd(()-> this.io.runIndexerAtSpeed(indexMotorSpeedSetpoint.times(-1)), ()-> this.io.stopIntake());
+        return Commands.runEnd(()-> this.io.runIndexerAtSpeed(indexMotorSpeedSetpoint.times(-1)), ()-> this.io.stopIndexer());
     }
 
     public Command stopIndexer(){
-        return Commands.runOnce(()-> this.io.stopIntake());
+        return Commands.runOnce(()-> this.io.stopIndexer());
     }
 
     public void setIndexMotorSpeedSetpoint(AngularVelocity speed){

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
@@ -25,5 +25,5 @@ public interface IndexerIO {
 
     public default void updateInputs(IndexerIOInputs inputs){}
     public default void runIndexerAtSpeed(AngularVelocity speed){}
-    public default void stopIntake(){}
+    public default void stopIndexer(){}
 }

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -45,31 +45,24 @@ public class Intake extends SubsystemBase {
   }
 
   public Command runIntakeExtension(Distance length) {
-    return Commands.runEnd(
+    return Commands.runOnce(
         () -> {
           intakeExtensionSetpoint = length;
-          this.io.setIntakeExtensionLength(length);},
-        () -> this.io.stopIntakeExtension());
+          this.io.setIntakeExtensionLength(length);});
   }
 
   public Command setIntakeMaxLength() {
-    return Commands.runEnd(
+    return Commands.runOnce(
         () -> {
           intakeExtensionSetpoint = Meters.of(IntakeConstants.intakeRotationsToRackRatio * IntakeConstants.intakeMaxExtensionLength);
-          this.io.setIntakeMaxLength();},
-        () -> this.io.stopIntakeExtension());
+          this.io.setIntakeMaxLength();});
   }
 
   public Command setIntakeMinLength() {
-    return Commands.runEnd(
+    return Commands.runOnce(
         () -> {
           intakeExtensionSetpoint = Meters.of(IntakeConstants.intakeRotationsToRackRatio * IntakeConstants.intakeMinExtensionLength);
-          this.io.setIntakeMinLength();},
-        () -> this.io.stopIntakeExtension());
-  }
-
-  public Command stopIntakeExtension() {
-    return Commands.runOnce(() -> this.io.stopIntakeExtension());
+          this.io.setIntakeMinLength();});
   }
 
   // Getters for private IO variables

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -40,6 +40,4 @@ public interface IntakeIO {
 
   public default void stopIntake() {}
 
-  public default void stopIntakeExtension() {}
-
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -90,8 +90,4 @@ public class IntakeIOSim implements IntakeIO {
     public void stopIntake() {
         intakeController.setSetpoint(0);
     }
-
-    public void stopIntakeExtension() {
-        rackController.setSetpoint(0);
-    }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonFX.java
@@ -10,7 +10,6 @@ import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
-import com.ctre.phoenix6.controls.StaticBrake;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
@@ -130,9 +129,5 @@ public class IntakeIOTalonFX implements IntakeIO {
 
     public void stopIntake() {
         intakeMotor.setControl(new CoastOut());
-    }
-
-    public void stopIntakeExtension() {
-        intakeMotor.setControl(new StaticBrake());
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -50,6 +50,9 @@ public class Shooter extends SubsystemBase{
     public Command runKicker(){
         return Commands.runEnd(() -> this.io.setKickerVelocity(kickerVelocitySetpoint), () -> this.io.stopKicker());
     }
+    public Command reverseKicker(){
+        return Commands.runEnd(() -> this.io.setKickerVelocity(kickerVelocitySetpoint.times(-0.25)), () -> this.io.stopKicker());
+    }
     public Command stopKicker(){
         return Commands.runOnce(() -> this.io.stopKicker());
     }


### PR DESCRIPTION
## Changed files
- RobotContainer: changed buttons
- Intake: added max/min extension commands
- IntakeIOTalonFx: I forgot (deleted an extra space maybe?)

## Control Scheme
### Joysticks/misc
- Left joystick: move
- Right joystick: rotate
- Right joystick button: lock to 0°
- Start button: set gyro to 0°

### Bumpers/triggers
- Right bumper: spin up shooter and lock to optimal rotation
- Right trigger: shoot
- Left bumper: toggle intake deployed/retracted
- Left trigger: run intake & indexer

### ABXY
- A: spin up shooter (will use right bumper in most cases, but in case you want to not lock to a rotation)
- B: climb/cancel climb (not implemented)
- X: set wheels to X configuration
- Y: outtake (both intake and indexer)

### D-pad
- Right: test all points
- Up: increase shooter speed
- Down: decrease shooter speed