### PR TITLE
Only build in CI on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:
@@ -12,7 +11,5 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Grant execute permission
-        run: chmod +x gradlew
       - name: Build robot code
         run: ./gradlew build


### PR DESCRIPTION
Depends on #35

If we list no branches on push and pull_request, it basically just always builds twice. No reason to do that, so figured just always building on push makes sense.