### PR TITLE
Update thread priority for the robotPeriodic method

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.wpilibj.Threads;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -81,7 +82,7 @@ public class Robot extends LoggedRobot {
   public void robotPeriodic() {
     // Optionally switch the thread to high priority to improve loop
     // timing (see the template project documentation for details)
-    // Threads.setCurrentThreadPriority(true, 99);
+    Threads.setCurrentThreadPriority(true, 99);
 
     // Poll the state machine
     robotContainer.stateMachine.poll();
@@ -94,8 +95,9 @@ public class Robot extends LoggedRobot {
     CommandScheduler.getInstance().run();
     robotContainer.updateRobotPose();
     robotPosition.setRobotPose(robotContainer.getRobotPosition());
+
     // Return to non-RT thread priority (do not modify the first argument)
-    // Threads.setCurrentThreadPriority(false, 10);
+    Threads.setCurrentThreadPriority(false, 10);
   }
 
   /** This function is called once when the robot is disabled. */


### PR DESCRIPTION
Last year's template had these uncommented by default, this year's was commented by default. We want to have higher priority in this section to ensure good loop timing.