### PR TITLE
Ensuring Coveralls doesn't fail the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,4 @@ jobs:
         uses:  coverallsapp/github-action@v2
         with:
           format: jacoco
+          fail-on-error: false


### PR DESCRIPTION
This ensures failing to connect to coveralls won't show up as a failed build. Already verified it on PR #76, this is just that same commit cherry picked.